### PR TITLE
Switched from serverjre to full JRE

### DIFF
--- a/jre9/Dockerfile
+++ b/jre9/Dockerfile
@@ -11,10 +11,8 @@ RUN \
         --silent \
         --show-error \
         --header "Cookie: oraclelicense=accept-securebackup-cookie" \
-        http://download.oracle.com/otn-pub/java/jdk/9.0.1+11/serverjre-9.0.1_linux-x64_bin.tar.gz | tar xz && \
-    mv jdk* java && \
+        http://download.oracle.com/otn-pub/java/jdk/9.0.1+11/jre-9.0.1_linux-x64_bin.tar.gz | tar xz && \
+    mv jre* java && \
     if [ ! -d "/opt/local/bin" ]; then mkdir -p "/opt/local/bin"; fi && \
     pushd local/bin && \
     for FILE in "${JAVA_HOME}/bin/"*; do ln -s "${FILE}" "$(basename ${FILE})"; done
-
-    


### PR DESCRIPTION
This allows us to make use of java.se.ee module, which is not part of serverjre, but we require SOAP classes which are only part of ee module.